### PR TITLE
Implement RCON client

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,2 @@
-export class Rcon {
-  // TODO: Implement RCON client
-}
+export { Rcon } from "./rcon";
+export type { RconOptions } from "./rcon";

--- a/src/rcon.ts
+++ b/src/rcon.ts
@@ -1,0 +1,116 @@
+import net from "node:net";
+import { EventEmitter } from "node:events";
+import { encodePacket, decodePacket, RconPacket } from "./packet";
+
+export interface RconOptions {
+  host: string;
+  port: number;
+  password: string;
+}
+
+export class Rcon extends EventEmitter {
+  private socket: net.Socket;
+  private options: RconOptions;
+  private buffer = Buffer.alloc(0);
+  private requestId = 0;
+  private pending = new Map<number, (data: string) => void>();
+  private authId: number | null = null;
+
+  constructor(options: RconOptions, socket?: net.Socket) {
+    super();
+    this.options = options;
+    this.socket = socket ?? new net.Socket();
+  }
+
+  connect(): void {
+    this.socket.on("connect", this.onConnect);
+    this.socket.on("data", this.onData);
+    this.socket.on("error", (err) => this.emit("error", err));
+    this.socket.on("end", () => this.emit("end"));
+    this.socket.on("close", () => this.emit("end"));
+    this.socket.connect(this.options.port, this.options.host);
+  }
+
+  send(command: string): Promise<string> {
+    const id = this.nextId();
+    const packet = encodePacket({ id, type: 2, body: command });
+
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, resolve);
+      this.socket.write(packet, (err) => {
+        if (err) {
+          this.pending.delete(id);
+          reject(err);
+        }
+      });
+    });
+  }
+
+  end(): void {
+    this.socket.end();
+  }
+
+  private nextId(): number {
+    this.requestId += 1;
+    return this.requestId;
+  }
+
+  private onConnect = () => {
+    this.emit("connect");
+    this.authenticate();
+  };
+
+  private authenticate(): void {
+    this.authId = this.nextId();
+    const packet = encodePacket({
+      id: this.authId,
+      type: 3,
+      body: this.options.password,
+    });
+    this.socket.write(packet);
+  }
+
+  private onData = (chunk: Buffer) => {
+    this.buffer = Buffer.concat([this.buffer, chunk]);
+
+    while (this.buffer.length >= 4) {
+      const length = this.buffer.readInt32LE(0);
+      if (this.buffer.length < length + 4) break;
+      const packetBuffer = this.buffer.subarray(0, length + 4);
+      this.buffer = this.buffer.subarray(length + 4);
+
+      let packet: RconPacket;
+      try {
+        packet = decodePacket(packetBuffer);
+      } catch (err) {
+        this.emit("error", err);
+        continue;
+      }
+
+      this.handlePacket(packet);
+    }
+  };
+
+  private handlePacket(packet: RconPacket): void {
+    if (
+      this.authId !== null &&
+      packet.id === this.authId &&
+      packet.type === 2
+    ) {
+      if (packet.id === -1) {
+        this.emit("error", new Error("Authentication failed"));
+        this.socket.end();
+      } else {
+        this.emit("authenticated");
+      }
+      return;
+    }
+
+    const pending = this.pending.get(packet.id);
+    if (pending) {
+      this.pending.delete(packet.id);
+      pending(packet.body);
+    }
+    this.emit("response", packet.body);
+  }
+}

--- a/tests/rcon.test.ts
+++ b/tests/rcon.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi } from "vitest";
+import { EventEmitter } from "node:events";
+import { Rcon, RconOptions } from "../src";
+import { encodePacket, decodePacket } from "../src/packet";
+
+class MockSocket extends EventEmitter {
+  public written: Buffer[] = [];
+  connect(_port: number, _host: string) {
+    void _port;
+    void _host;
+    this.emit("connect");
+  }
+  write(data: Buffer, cb?: (err?: Error | null) => void) {
+    this.written.push(Buffer.from(data));
+    cb?.(null);
+    return true;
+  }
+  end() {
+    this.emit("end");
+  }
+  send(buffer: Buffer) {
+    this.emit("data", buffer);
+  }
+}
+
+describe("Rcon class", () => {
+  const options: RconOptions = {
+    host: "localhost",
+    port: 27015,
+    password: "p",
+  };
+
+  it("authenticates and sends commands", async () => {
+    const socket = new MockSocket();
+    const rcon = new Rcon(options, socket as any);
+
+    const onConnect = vi.fn();
+    const onAuth = vi.fn();
+    const onResponse = vi.fn();
+    const onEnd = vi.fn();
+    rcon.on("connect", onConnect);
+    rcon.on("authenticated", onAuth);
+    rcon.on("response", onResponse);
+    rcon.on("end", onEnd);
+
+    rcon.connect();
+    expect(onConnect).toHaveBeenCalled();
+
+    const authPacket = decodePacket(socket.written.shift()!);
+    expect(authPacket.body).toBe(options.password);
+
+    socket.send(encodePacket({ id: authPacket.id, type: 2, body: "" }));
+    expect(onAuth).toHaveBeenCalled();
+
+    const promise = rcon.send("status");
+    const cmdPacket = decodePacket(socket.written.shift()!);
+    expect(cmdPacket.body).toBe("status");
+
+    const respBuf = encodePacket({ id: cmdPacket.id, type: 0, body: "ok" });
+    socket.send(respBuf.subarray(0, 5));
+    socket.send(respBuf.subarray(5));
+
+    await expect(promise).resolves.toBe("ok");
+    expect(onResponse).toHaveBeenCalledWith("ok");
+
+    socket.end();
+    expect(onEnd).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add actual `Rcon` implementation
- expose `Rcon` from index
- create tests with mocked socket

## Testing
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_685fd213f2fc8326a0598e1ae0a6d669