### PR TITLE
Add isAuth helper function

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,0 +1,32 @@
+import { Rcon, type RconOptions } from "./rcon";
+
+export async function isAuth(options: RconOptions): Promise<boolean> {
+  return new Promise((resolve) => {
+    const rcon = new Rcon(options);
+    let settled = false;
+
+    const cleanup = () => {
+      rcon.off("authenticated", onAuth);
+      rcon.off("error", onFail);
+      rcon.off("end", onFail);
+    };
+
+    const done = (result: boolean) => {
+      if (!settled) {
+        settled = true;
+        cleanup();
+        rcon.end();
+        resolve(result);
+      }
+    };
+
+    const onAuth = () => done(true);
+    const onFail = () => done(false);
+
+    rcon.on("authenticated", onAuth);
+    rcon.on("error", onFail);
+    rcon.on("end", onFail);
+
+    rcon.connect();
+  });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export { Rcon } from "./rcon";
 export type { RconOptions } from "./rcon";
+export { isAuth } from "./helpers";

--- a/tests/helpers.test.ts
+++ b/tests/helpers.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from "vitest";
+
+const instances: any[] = [];
+
+vi.mock("../src/rcon", async () => {
+  const { EventEmitter } = await import("node:events");
+  return {
+    __esModule: true,
+    Rcon: class MockRcon extends EventEmitter {
+      connect = vi.fn();
+      end = vi.fn();
+      constructor() {
+        super();
+        instances.push(this);
+      }
+    },
+  };
+});
+
+import { isAuth } from "../src/helpers";
+
+describe("isAuth", () => {
+  it("resolves true when authenticated", async () => {
+    const promise = isAuth({ host: "h", port: 1, password: "p" } as any);
+    const inst = instances.pop()!;
+    inst.emit("authenticated");
+    await expect(promise).resolves.toBe(true);
+    expect(inst.end).toHaveBeenCalled();
+  });
+
+  it("resolves false on error", async () => {
+    const promise = isAuth({ host: "h", port: 1, password: "p" } as any);
+    const inst = instances.pop()!;
+    inst.emit("error", new Error("fail"));
+    await expect(promise).resolves.toBe(false);
+    expect(inst.end).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add `isAuth` helper to attempt auth with Rcon
- re-export helper from library entry
- test helper using mocked Rcon

## Testing
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_685fd3cc66488326b39fc8e18fc3b945