### PR TITLE
Add integration test for real RCON server

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,20 @@ To get started with development:
     npm test
     ```
 
+### Manual integration test
+
+The test suite includes an optional integration test that connects to a real RCON server.
+To run it, set the following environment variables before executing `npm test`:
+
+```bash
+export RCON_HOST=127.0.0.1
+export RCON_PORT=25575
+export RCON_PASSWORD=secret
+npm test
+```
+
+If these variables are not set, the integration test will be skipped.
+
 ## Contributing
 
 Contributions are welcome! If you'd like to add support for a new game, fix a bug, or improve the library, please open an issue or submit a pull request.

--- a/tests/integration/rcon.integration.test.ts
+++ b/tests/integration/rcon.integration.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { isAuth } from "../../src/helpers";
+
+const host = process.env.RCON_HOST;
+const port = process.env.RCON_PORT;
+const password = process.env.RCON_PASSWORD;
+
+const missing = !host || !port || !password;
+
+const testFn = missing ? it.skip : it;
+
+describe("RCON integration", () => {
+  testFn(
+    "connects and authenticates with a real server" +
+      (missing ? " (set RCON_HOST, RCON_PORT and RCON_PASSWORD to run)" : ""),
+    async () => {
+      if (missing) return;
+      const authenticated = await isAuth({
+        host: host!,
+        port: parseInt(port!, 10),
+        password: password!,
+      });
+      expect(authenticated).toBe(true);
+    }
+  );
+});


### PR DESCRIPTION
## Summary
- add optional integration test that checks real RCON auth via environment variables
- document how to run the integration test

## Testing
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_685fd5221a3c8326a16c5c18dba69d5d