### PR TITLE
Implement Arma Reforger RCON client

### DIFF
--- a/src/clients/arma-reforger.client.ts
+++ b/src/clients/arma-reforger.client.ts
@@ -1,15 +1,96 @@
+import { Socket, createSocket } from "node:dgram";
 import { BaseClient } from "./base.client";
+import {
+  ArmaReforgerResponseType,
+  createAuthPacket,
+  createCommandPacket,
+  parsePacket,
+} from "../utils/arma-reforger.utils";
 
 export class ArmaReforgerClient extends BaseClient {
+  private socket: Socket | null = null;
+  private seq = 0;
+
   public connect(): Promise<void> {
-    throw new Error("Method not implemented.");
+    return new Promise((resolve, reject) => {
+      this.socket = createSocket("udp4");
+      const socket = this.socket;
+
+      const timeout = setTimeout(() => {
+        socket.close();
+        reject(new Error("Authentication timed out."));
+      }, this.options.timeout ?? 5000);
+
+      const onMessage = (msg: Buffer): void => {
+        const packet = parsePacket(msg);
+        if (packet.type === ArmaReforgerResponseType.AUTH) {
+          socket.off("message", onMessage);
+          clearTimeout(timeout);
+          if (packet.success) {
+            this.emit("connect");
+            this.emit("authenticated");
+            socket.on("message", (data) => this.handleMessage(data));
+            resolve();
+          } else {
+            socket.close();
+            reject(new Error("Authentication failed."));
+          }
+        }
+      };
+
+      socket.on("message", onMessage);
+      socket.on("error", (err) => {
+        socket.close();
+        reject(err);
+      });
+      socket.on("close", () => this.emit("end"));
+
+      const packet = createAuthPacket(this.options.password);
+      socket.send(packet, this.options.port, this.options.host);
+    });
   }
 
-  public send(): Promise<string> {
-    throw new Error("Method not implemented.");
+  private handleMessage(msg: Buffer): void {
+    const packet = parsePacket(msg);
+    if (packet.type === ArmaReforgerResponseType.COMMAND) {
+      this.emit("response", packet.payload);
+    }
+  }
+
+  public send(command: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+      if (!this.socket) {
+        return reject(new Error("Socket not connected."));
+      }
+
+      const seq = this.seq++ & 0xff;
+      const packet = createCommandPacket(seq, command);
+
+      const onMessage = (msg: Buffer): void => {
+        const data = parsePacket(msg);
+        if (
+          data.type === ArmaReforgerResponseType.COMMAND &&
+          data.seq === seq
+        ) {
+          this.socket?.off("message", onMessage);
+          resolve(data.payload);
+        }
+      };
+
+      this.socket.on("message", onMessage);
+      this.socket.send(packet, this.options.port, this.options.host, (err) => {
+        if (err) {
+          this.socket?.off("message", onMessage);
+          reject(err);
+        }
+      });
+    });
   }
 
   public end(): void {
-    throw new Error("Method not implemented.");
+    if (this.socket) {
+      this.socket.close();
+      this.socket = null;
+    }
   }
 }

--- a/src/utils/arma-reforger.utils.ts
+++ b/src/utils/arma-reforger.utils.ts
@@ -1,0 +1,54 @@
+export enum ArmaReforgerPacketType {
+  AUTH = 0,
+  COMMAND = 1,
+}
+
+export enum ArmaReforgerResponseType {
+  AUTH = 0,
+  COMMAND = 1,
+}
+
+export interface ParsedPacket {
+  type: ArmaReforgerResponseType;
+  seq: number;
+  payload: string;
+  success?: boolean;
+}
+
+export function createAuthPacket(password: string): Buffer {
+  const pw = Buffer.from(password, "utf8");
+  const buf = Buffer.alloc(6 + pw.length);
+  buf.write("BE", 0, "ascii");
+  buf.writeUInt8(0x00, 2);
+  buf.writeUInt8(0xff, 3);
+  buf.writeUInt8(ArmaReforgerPacketType.AUTH, 4);
+  pw.copy(buf, 5);
+  buf.writeUInt8(0x00, 5 + pw.length);
+  return buf;
+}
+
+export function createCommandPacket(seq: number, command: string): Buffer {
+  const cmd = Buffer.from(command, "utf8");
+  const buf = Buffer.alloc(6 + cmd.length);
+  buf.write("BE", 0, "ascii");
+  buf.writeUInt8(0x00, 2);
+  buf.writeUInt8(seq & 0xff, 3);
+  buf.writeUInt8(ArmaReforgerPacketType.COMMAND, 4);
+  cmd.copy(buf, 5);
+  buf.writeUInt8(0x00, 5 + cmd.length);
+  return buf;
+}
+
+export function parsePacket(buf: Buffer): ParsedPacket {
+  const type =
+    buf[4] === ArmaReforgerPacketType.AUTH
+      ? ArmaReforgerResponseType.AUTH
+      : ArmaReforgerResponseType.COMMAND;
+  const seq = buf[3];
+  const payload = buf.toString("utf8", 5, buf.length);
+  const success =
+    type === ArmaReforgerResponseType.AUTH
+      ? payload.trim() === "OK"
+      : undefined;
+  return { type, seq, payload, success };
+}


### PR DESCRIPTION
## Summary
- implement Arma Reforger RCON client using UDP Battleye style packets
- add helpers for building and parsing Arma Reforger packets
- wire up event handling similar to Rust client

## Testing
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_68605d5505ac8326b9f21e728309d8af