### PR TITLE
Implement Palworld client

### DIFF
--- a/src/clients/palworld.client.ts
+++ b/src/clients/palworld.client.ts
@@ -1,15 +1,148 @@
+import { Socket, createConnection } from "node:net";
 import { BaseClient } from "./base.client";
+import {
+  createPacket,
+  PACKET_TYPE_AUTH,
+  PACKET_TYPE_AUTH_RESPONSE,
+  PACKET_TYPE_COMMAND,
+  PACKET_TYPE_RESPONSE,
+} from "../utils/packet";
+import { parsePackets } from "../utils/palworld.utils";
 
 export class PalworldClient extends BaseClient {
+  private socket: Socket | null = null;
+  private requestId = 0;
+  private pending = new Map<number, (data: string) => void>();
+  private connected = false;
+  private authenticated = false;
+  private buffer = Buffer.alloc(0);
+  private authCallback: ((err?: Error) => void) | null = null;
+
   public connect(): Promise<void> {
-    throw new Error("Method not implemented.");
+    return new Promise((resolve, reject) => {
+      this.socket = createConnection(
+        { host: this.options.host, port: this.options.port },
+        () => {
+          this.connected = true;
+          this.emit("connect");
+          this.authenticate().then(resolve).catch(reject);
+        }
+      );
+
+      this.socket.on("data", (data) => this.onData(data));
+      this.socket.on("error", (err) => this.emit("error", err));
+      this.socket.on("end", () => {
+        this.connected = false;
+        this.authenticated = false;
+        this.emit("end");
+      });
+
+      if (this.options.timeout) {
+        this.socket.setTimeout(this.options.timeout, () => {
+          if (!this.connected) {
+            const err = new Error("Connection timed out.");
+            this.emit("error", err);
+            this.end();
+            reject(err);
+          }
+        });
+      }
+    });
   }
 
-  public send(): Promise<string> {
-    throw new Error("Method not implemented.");
+  private authenticate(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.authCallback?.(new Error("Authentication timed out."));
+      }, this.options.timeout ?? 5000);
+
+      this.authCallback = (err) => {
+        clearTimeout(timeout);
+        if (err) {
+          this.end();
+          reject(err);
+        } else {
+          this.authenticated = true;
+          this.emit("authenticated");
+          resolve();
+        }
+        this.authCallback = null;
+      };
+
+      this.sendPacket(PACKET_TYPE_AUTH, this.options.password).catch((err) => {
+        this.authCallback?.(err);
+      });
+    });
+  }
+
+  private onData(data: Buffer): void {
+    this.buffer = Buffer.concat([this.buffer, data]);
+    const { packets, remaining } = parsePackets(this.buffer);
+    this.buffer = remaining;
+
+    for (const packet of packets) {
+      const { id, type, body } = packet;
+
+      if (this.authCallback) {
+        if (type === PACKET_TYPE_AUTH_RESPONSE) {
+          if (id === -1) {
+            this.authCallback(new Error("Authentication failed."));
+          } else if (id === this.requestId) {
+            this.authCallback();
+          }
+        } else if (type === PACKET_TYPE_RESPONSE) {
+          // Palworld may send an empty response during auth which can be ignored
+        }
+        continue;
+      }
+
+      if (type === PACKET_TYPE_RESPONSE) {
+        const resolve = this.pending.get(id);
+        if (resolve) {
+          resolve(body);
+          this.pending.delete(id);
+        } else {
+          this.emit("response", body);
+        }
+      }
+    }
+  }
+
+  public send(command: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+      if (!this.authenticated) {
+        return reject(new Error("Not authenticated."));
+      }
+      this.sendPacket(PACKET_TYPE_COMMAND, command)
+        .then((id) => {
+          this.pending.set(id, resolve);
+        })
+        .catch(reject);
+    });
+  }
+
+  private sendPacket(type: number, body: string): Promise<number> {
+    return new Promise((resolve, reject) => {
+      if (!this.socket) {
+        return reject(new Error("Socket not connected."));
+      }
+
+      const id = ++this.requestId;
+      const buffer = createPacket(id, type, body);
+
+      this.socket.write(buffer, (err) => {
+        if (err) {
+          return reject(err);
+        }
+        resolve(id);
+      });
+    });
   }
 
   public end(): void {
-    throw new Error("Method not implemented.");
+    if (this.socket) {
+      this.socket.end();
+      this.socket = null;
+    }
   }
 }

--- a/src/utils/palworld.utils.ts
+++ b/src/utils/palworld.utils.ts
@@ -1,0 +1,27 @@
+export interface RconPacket {
+  id: number;
+  type: number;
+  body: string;
+}
+
+export function parsePackets(buffer: Buffer): {
+  packets: RconPacket[];
+  remaining: Buffer;
+} {
+  const packets: RconPacket[] = [];
+  let offset = 0;
+  while (buffer.length >= offset + 4) {
+    const size = buffer.readInt32LE(offset);
+    if (buffer.length < offset + 4 + size) {
+      break;
+    }
+    const packetBuf = buffer.subarray(offset + 4, offset + 4 + size);
+    const id = packetBuf.readInt32LE(0);
+    const type = packetBuf.readInt32LE(4);
+    const body = packetBuf.toString("utf8", 8, packetBuf.length - 2);
+    packets.push({ id, type, body });
+    offset += 4 + size;
+  }
+  const remaining = buffer.subarray(offset);
+  return { packets, remaining };
+}


### PR DESCRIPTION
## Summary
- add parser helper for Palworld packets
- implement Palworld RCON client using Source style protocol

## Testing
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_68605d5836748326a018ea3b2e1ff4ff