### PR TITLE
Implement SCUM client

### DIFF
--- a/src/clients/scum.client.ts
+++ b/src/clients/scum.client.ts
@@ -1,15 +1,100 @@
+import { createSocket, Socket } from "node:dgram";
 import { BaseClient } from "./base.client";
+import {
+  createCommandPacket,
+  createLoginPacket,
+  parsePacket,
+  SCUM_PACKET_TYPE_COMMAND,
+  SCUM_PACKET_TYPE_LOGIN,
+} from "../utils/scum.utils";
 
 export class ScumClient extends BaseClient {
+  private socket: Socket | null = null;
+  private sessionId = 0;
+  private requestId = 0;
+  private pending = new Map<number, (data: string) => void>();
+  private connectResolver: (() => void) | null = null;
+
   public connect(): Promise<void> {
-    throw new Error("Method not implemented.");
+    return new Promise((resolve, reject) => {
+      this.socket = createSocket("udp4");
+      this.connectResolver = resolve;
+
+      const timeout = setTimeout(() => {
+        reject(new Error("Connection timed out."));
+        this.end();
+      }, this.options.timeout ?? 5000);
+
+      const onError = (err: Error): void => {
+        clearTimeout(timeout);
+        this.end();
+        reject(err);
+      };
+
+      this.socket.once("error", onError);
+      this.socket.on("message", (msg) => {
+        try {
+          const packet = parsePacket(msg);
+          if (packet.type === SCUM_PACKET_TYPE_LOGIN) {
+            clearTimeout(timeout);
+            this.sessionId = packet.id;
+            this.emit("connect");
+            this.emit("authenticated");
+            this.connectResolver?.();
+            this.connectResolver = null;
+          } else if (packet.type === SCUM_PACKET_TYPE_COMMAND) {
+            const cb = this.pending.get(packet.id);
+            if (cb) {
+              cb(packet.payload);
+              this.pending.delete(packet.id);
+            } else {
+              this.emit("response", packet.payload);
+            }
+          } else {
+            this.emit("response", packet.payload);
+          }
+        } catch (err) {
+          this.emit("error", err as Error);
+        }
+      });
+
+      this.socket.on("close", () => this.emit("end"));
+
+      const loginPacket = createLoginPacket(this.options.password);
+      this.socket.send(
+        loginPacket,
+        this.options.port,
+        this.options.host,
+        (err) => {
+          if (err) {
+            onError(err);
+          }
+        }
+      );
+    });
   }
 
-  public send(): Promise<string> {
-    throw new Error("Method not implemented.");
+  public send(command: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+      if (!this.socket || this.sessionId === 0) {
+        return reject(new Error("Not connected."));
+      }
+      const id = ++this.requestId;
+      this.pending.set(id, resolve);
+      const packet = createCommandPacket(this.sessionId, id, command);
+      this.socket.send(packet, this.options.port, this.options.host, (err) => {
+        if (err) {
+          this.pending.delete(id);
+          reject(err);
+        }
+      });
+    });
   }
 
   public end(): void {
-    throw new Error("Method not implemented.");
+    if (this.socket) {
+      this.socket.close();
+      this.socket = null;
+    }
   }
 }

--- a/src/utils/scum.utils.ts
+++ b/src/utils/scum.utils.ts
@@ -1,0 +1,45 @@
+export const SCUM_PACKET_TYPE_LOGIN = 0x00;
+export const SCUM_PACKET_TYPE_COMMAND = 0x01;
+export const SCUM_PACKET_TYPE_MESSAGE = 0x02;
+
+export interface ScumPacket {
+  type: number;
+  id: number;
+  payload: string;
+}
+
+export function createLoginPacket(password: string): Buffer {
+  const pwd = Buffer.from(password + "\0", "utf8");
+  const buf = Buffer.alloc(7 + pwd.length);
+  buf.write("BE", 0, "ascii");
+  buf.writeUInt8(SCUM_PACKET_TYPE_LOGIN, 2);
+  buf.writeUInt32BE(0, 3); // login has id 0
+  pwd.copy(buf, 7);
+  return buf;
+}
+
+export function createCommandPacket(
+  sessionId: number,
+  id: number,
+  command: string
+): Buffer {
+  const body = Buffer.from(command + "\0", "utf8");
+  const buf = Buffer.alloc(11 + body.length);
+  buf.write("BE", 0, "ascii");
+  buf.writeUInt8(SCUM_PACKET_TYPE_COMMAND, 2);
+  buf.writeUInt32BE(sessionId, 3);
+  buf.writeUInt32BE(id, 7);
+  body.copy(buf, 11);
+  return buf;
+}
+
+export function parsePacket(data: Buffer): ScumPacket {
+  if (data.toString("ascii", 0, 2) !== "BE") {
+    throw new Error("Invalid packet header");
+  }
+  const type = data.readUInt8(2);
+  const id = data.readUInt32BE(3);
+  const payload =
+    data.length > 7 ? data.toString("utf8", 7).replace(/\0+$/, "") : "";
+  return { type, id, payload };
+}


### PR DESCRIPTION
## Summary
- add SCUM RCON utilities for packet handling
- implement SCUM RCON client with connect, send and end

## Testing
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_68605d57a0c083269881a4bfd5e44588