### PR TITLE
docs: clarify valheim rcon requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ Additionally, this is based on a default implementation of the vanilla server in
 - [ ] SCUM
 - [ ] Valheim
 
+> **Note**
+> Valheim does not include native RCON functionality. Integration with this library only works when using the
+> [rcon plugin](https://thunderstore.io/c/valheim/p/AviiNL/rcon/) from the
+> [BepInExPack](https://thunderstore.io/c/valheim/p/denikson/BepInExPack_Valheim/).
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
## Summary
- clarify that Valheim requires installing the BepInExPack and rcon plugin to use RCON

## Testing
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_68619273ddf08326ade1a3c75e39f5c6