### PR TITLE
feat(scum): adopt BattlEye packets

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,10 @@ Additionally, this is based on a default implementation of the vanilla server in
 - [x] Minecraft
 - [x] Rust
 - [x] Palworld
+- [x] SCUM
 - [x] Valheim
 
 ### In Testing
-
-### In Progress
-
-- [ ] SCUM
 
 > **Note**
 > Valheim does not include native RCON functionality. Integration with this library only works when using the

--- a/src/clients/scum.client.ts
+++ b/src/clients/scum.client.ts
@@ -1,90 +1,113 @@
-import { createSocket, Socket } from "node:dgram";
+import { Socket, createSocket } from "node:dgram";
 import { BaseClient } from "./base.client";
 import {
+  ScumPacketType,
+  createAckPacket,
   createCommandPacket,
   createLoginPacket,
   parsePacket,
-  SCUM_PACKET_TYPE_COMMAND,
-  SCUM_PACKET_TYPE_LOGIN,
 } from "../utils/scum.utils";
 
 export class ScumClient extends BaseClient {
   private socket: Socket | null = null;
-  private sessionId = 0;
-  private requestId = 0;
-  private pending = new Map<number, (data: string) => void>();
-  private connectResolver: (() => void) | null = null;
+  private seq = 0;
+  private keepAlive: NodeJS.Timeout | null = null;
 
   public connect(): Promise<void> {
     return new Promise((resolve, reject) => {
       this.socket = createSocket("udp4");
-      this.connectResolver = resolve;
+      const socket = this.socket;
 
       const timeout = setTimeout(() => {
-        reject(new Error("Connection timed out."));
-        this.end();
+        socket.close();
+        reject(new Error("Authentication timed out."));
       }, this.options.timeout ?? 5000);
 
-      const onError = (err: Error): void => {
-        clearTimeout(timeout);
-        this.end();
-        reject(err);
-      };
-
-      this.socket.once("error", onError);
-      this.socket.on("message", (msg) => {
-        try {
-          const packet = parsePacket(msg);
-          if (packet.type === SCUM_PACKET_TYPE_LOGIN) {
-            clearTimeout(timeout);
-            this.sessionId = packet.id;
+      const onMessage = (msg: Buffer): void => {
+        const packet = parsePacket(msg);
+        if (packet.type === ScumPacketType.LOGIN) {
+          socket.off("message", onMessage);
+          clearTimeout(timeout);
+          if (packet.success) {
             this.emit("connect");
             this.emit("authenticated");
-            this.connectResolver?.();
-            this.connectResolver = null;
-          } else if (packet.type === SCUM_PACKET_TYPE_COMMAND) {
-            const cb = this.pending.get(packet.id);
-            if (cb) {
-              cb(packet.payload);
-              this.pending.delete(packet.id);
-            } else {
-              this.emit("response", packet.payload);
-            }
+            socket.on("message", (data) => this.handleMessage(data));
+            this.keepAlive = setInterval(() => {
+              // BattlEye requires a keep-alive packet every <45 seconds.
+              // An empty command packet is sufficient.
+              this.send("");
+            }, 30_000);
+            resolve();
           } else {
-            this.emit("response", packet.payload);
+            socket.close();
+            reject(new Error("Authentication failed."));
           }
-        } catch (err) {
-          this.emit("error", err as Error);
         }
+      };
+
+      socket.on("message", onMessage);
+      socket.on("error", (err) => {
+        socket.close();
+        reject(err);
+      });
+      socket.on("close", () => {
+        if (this.keepAlive) {
+          clearInterval(this.keepAlive);
+        }
+        this.emit("end");
       });
 
-      this.socket.on("close", () => this.emit("end"));
-
-      const loginPacket = createLoginPacket(this.options.password);
-      this.socket.send(
-        loginPacket,
-        this.options.port,
-        this.options.host,
-        (err) => {
-          if (err) {
-            onError(err);
-          }
-        }
-      );
+      const packet = createLoginPacket(this.options.password);
+      socket.send(packet, this.options.port, this.options.host);
     });
+  }
+
+  private handleMessage(msg: Buffer): void {
+    try {
+      const packet = parsePacket(msg);
+
+      if (packet.type === ScumPacketType.MESSAGE) {
+        this.emit("response", packet.payload.toString("ascii"));
+        if (this.socket) {
+          const ack = createAckPacket(packet.seq);
+          this.socket.send(ack, this.options.port, this.options.host);
+        }
+      } else if (packet.type === ScumPacketType.COMMAND) {
+        // These are responses to commands sent via `send()`
+        // and are handled by listeners on the socket there.
+      }
+    } catch (e) {
+      this.emit("error", e as Error);
+    }
   }
 
   public send(command: string): Promise<string> {
     return new Promise((resolve, reject) => {
-      if (!this.socket || this.sessionId === 0) {
-        return reject(new Error("Not connected."));
+      if (!this.socket) {
+        return reject(new Error("Socket not connected."));
       }
-      const id = ++this.requestId;
-      this.pending.set(id, resolve);
-      const packet = createCommandPacket(this.sessionId, id, command);
+
+      const seq = this.seq;
+      this.seq = (this.seq + 1) & 0xff;
+
+      const packet = createCommandPacket(seq, command);
+
+      const onMessage = (msg: Buffer): void => {
+        try {
+          const data = parsePacket(msg);
+          if (data.type === ScumPacketType.COMMAND && data.seq === seq) {
+            this.socket?.off("message", onMessage);
+            resolve(data.payload.toString("ascii"));
+          }
+        } catch {
+          // Ignore parsing errors for other packet types
+        }
+      };
+
+      this.socket.on("message", onMessage);
       this.socket.send(packet, this.options.port, this.options.host, (err) => {
         if (err) {
-          this.pending.delete(id);
+          this.socket?.off("message", onMessage);
           reject(err);
         }
       });


### PR DESCRIPTION
## Summary
- rework SCUM client to use BattlEye protocol
- update SCUM packet helpers
- document SCUM as supported

## Testing
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_6861a1c799788326b4b3b05b030bda64