### PR TITLE
Fix build for dual module output

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     }
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && tsc --project tsconfig.cjs.json",
     "dev": "tsc --watch",
     "lint": "eslint src/**/*.ts tests/**/*.ts",
     "lint:fix": "eslint src/**/*.ts tests/**/*.ts --fix",

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "outDir": "./dist",
+    "declaration": false,
+    "declarationMap": false,
+    "moduleResolution": "node"
+  }
+}


### PR DESCRIPTION
## Summary
- add CJS build via tsconfig.cjs.json
- update build script to produce both ESM and CJS outputs

## Testing
- `npm run build`
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_6861d3e9c23c83269ddaaaeef889cbff